### PR TITLE
Update log4j to 2.17 to address CVE-2021-45105.

### DIFF
--- a/logging-modules/log4j/pom.xml
+++ b/logging-modules/log4j/pom.xml
@@ -45,11 +45,11 @@
             <version>${disruptor.version}</version>
         </dependency>
     </dependencies>
-
-    <properties>
-        <log4j.version>1.2.17</log4j.version>
-        <log4j-api.version>2.7</log4j-api.version>
-        <log4j-core.version>2.7</log4j-core.version>
+         
+ <properties>
+        <log4j.version>2.17.0</log4j.version>
+        <log4j-api.version>2.17.0</log4j-api.version>
+        <log4j-core.version>2.17.0</log4j-core.version>
         <disruptor.version>3.3.6</disruptor.version>
     </properties>
 


### PR DESCRIPTION
https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-45105